### PR TITLE
Add safety and dependency analysis

### DIFF
--- a/ANALYSIS-SAFETY.md
+++ b/ANALYSIS-SAFETY.md
@@ -1,0 +1,53 @@
+# Analysis-Safety Report
+
+## Summary
+This repository provides a TypeScript client for TheBrain API, offering type-safe access to various endpoints and featuring request rate limiting and logging. The codebase appears generally well-structured and free of obfuscated or malicious logic, but dependency vulnerabilities and failing tests warrant attention.
+
+## Go / No-Go Recommendation
+**Recommendation: No-Go**
+
+The repository demonstrates sound coding practices, yet unresolved dependency vulnerabilities (including one critical issue) and failing end-to-end tests prevent an unconditional recommendation.
+
+## Analysis Criteria
+- Code quality and security practices
+- Dependencies (third-party libraries)
+- Documentation completeness and accuracy
+- Configuration and deployment scripts
+- Project and commit history
+
+## Detailed Findings
+### Code Quality and Security Practices
+- The client enforces configuration validation using Zod and sets up rate limiting and logging interceptors on Axios requests and responses【F:src/index.ts†L14-L58】.
+- Logging sanitizes sensitive headers (authorization, cookies) before outputting data【F:src/logger.ts†L46-L55】.
+- No use of dynamic code evaluation (e.g., `eval`) or filesystem access beyond build configuration was detected.
+
+### Dependencies
+- Core dependencies include `axios`, `bunyan`, and `zod`【F:package.json†L34-L38】.
+- `yarn audit` reports 11 vulnerabilities (10 low, 1 critical) including a critical issue in `form-data` used by `axios`【f7e7f6†L67-L107】.
+
+### Documentation
+- README describes installation and usage with example code, offering a concise overview of the client’s capabilities【F:README.md†L1-L40】.
+- Additional documentation such as CODE_OF_CONDUCT and design analysis is present but high-level.
+
+### Configuration and Build Scripts
+- Rollup configuration builds both CommonJS and ESM bundles and minified versions; no suspicious build steps were observed【F:rollup.config.js†L1-L60】.
+- TypeScript configuration targets ES2018 and excludes test files from build output【F:tsconfig.json†L1-L17】.
+
+### Project and Commit History
+- Commit history shows incremental feature additions and test improvements; no commits suggest malicious intent【40b8e6†L1-L12】.
+
+### Testing
+- Running `npm test` triggers multiple failures due to missing `THEBRAIN_API_KEY` environment variable, so end-to-end tests cannot complete【d732a4†L1-L54】.
+
+## Reasoning
+The lack of suspicious code patterns and the presence of security-conscious practices (validation, sanitized logging) are positive indicators. However, unresolved third-party vulnerabilities and inability to execute the test suite due to missing environment configuration introduce risk and reduce confidence in stability.
+
+## Recommendations
+- Upgrade or replace vulnerable dependencies, particularly the `form-data` package pulled in by `axios`.
+- Address low-severity `brace-expansion` issues by updating related packages (`eslint`, `@typescript-eslint/*`, etc.).
+- Provide mock credentials or a way to skip API-dependent tests to allow basic CI validation without secrets.
+- Expand documentation to clarify security posture and dependency management policies.
+
+## Error Handling
+- Test execution failed because required environment variables were absent, preventing completion of end-to-end tests.
+- `npm audit` could not run due to missing `package-lock.json`; `yarn audit` was used instead.


### PR DESCRIPTION
## Summary
- add comprehensive safety review of TheBrain API client
- document dependency vulnerabilities and test limitations

## Testing
- `npm test` *(fails: THEBRAIN_API_KEY environment variable is required for running end-to-end tests)*
- `yarn audit`

------
https://chatgpt.com/codex/tasks/task_b_68b52484d9b083259d02d126dace3179