### PR TITLE
Encode note image params and validate

### DIFF
--- a/src/__tests__/mocked/notes-images.test.ts
+++ b/src/__tests__/mocked/notes-images.test.ts
@@ -15,11 +15,11 @@ describe('NotesImagesApi', () => {
     describe('getNoteImage', () => {
         it('should get note image as ArrayBuffer', async () => {
             const brainId = '123e4567-e89b-12d3-a456-426614174000';
-            const token = 'test-token';
-            const filename = 'test-image.jpg';
+            const token = 'test token+value';
+            const filename = 'test image (1).jpg';
             const mockImageData = new ArrayBuffer(8);
 
-            mock.onGet(`/notes-images/${brainId}/${token}/${filename}`)
+            mock.onGet(`/notes-images/${brainId}/${encodeURIComponent(token)}/${encodeURIComponent(filename)}`)
                 .reply(200, mockImageData, {
                     'content-type': 'image/jpeg'
                 });
@@ -30,27 +30,25 @@ describe('NotesImagesApi', () => {
         });
 
         it('should throw error on invalid parameters', async () => {
-            const brainId = 'invalid-uuid';
-            const token = 'test-token';
-            const filename = 'test-image.jpg';
+            const brainId = '123e4567-e89b-12d3-a456-426614174000';
 
-            await expect(api.getNoteImage(brainId, token, filename))
-                .rejects
-                .toThrow();
+            await expect(api.getNoteImage('invalid-uuid', 'token', 'file.jpg')).rejects.toThrow();
+            await expect(api.getNoteImage(brainId, '../token', 'file.jpg')).rejects.toThrow();
+            await expect(api.getNoteImage(brainId, 'token', '../file.jpg')).rejects.toThrow();
         });
     });
 
     describe('getNoteImageAsDataUrl', () => {
         it('should convert image to base64 data URL', async () => {
             const brainId = '123e4567-e89b-12d3-a456-426614174000';
-            const token = 'test-token';
-            const filename = 'test-image.jpg';
-            const mimeType = 'image/jpeg';
+            const token = 'token with space';
+            const filename = 'note image.png';
+            const mimeType = 'image/png';
             const mockImageData = new ArrayBuffer(8);
             const mockImageArray = new Uint8Array(mockImageData);
             mockImageArray.fill(1); // Fill with some test data
 
-            mock.onGet(`/notes-images/${brainId}/${token}/${filename}`)
+            mock.onGet(`/notes-images/${brainId}/${encodeURIComponent(token)}/${encodeURIComponent(filename)}`)
                 .reply(200, mockImageData, {
                     'content-type': mimeType
                 });
@@ -60,14 +58,12 @@ describe('NotesImagesApi', () => {
         });
 
         it('should throw error on invalid parameters', async () => {
-            const brainId = 'invalid-uuid';
-            const token = 'test-token';
-            const filename = 'test-image.jpg';
+            const brainId = '123e4567-e89b-12d3-a456-426614174000';
             const mimeType = 'image/jpeg';
 
-            await expect(api.getNoteImageAsDataUrl(brainId, token, filename, mimeType))
-                .rejects
-                .toThrow();
+            await expect(api.getNoteImageAsDataUrl('invalid-uuid', 'token', 'file.jpg', mimeType)).rejects.toThrow();
+            await expect(api.getNoteImageAsDataUrl(brainId, '../token', 'file.jpg', mimeType)).rejects.toThrow();
+            await expect(api.getNoteImageAsDataUrl(brainId, 'token', '../file.jpg', mimeType)).rejects.toThrow();
         });
     });
-}); 
+});

--- a/src/notes-images.ts
+++ b/src/notes-images.ts
@@ -2,10 +2,16 @@ import { AxiosInstance } from "axios";
 import { z } from "zod";
 
 // Schema for note image request parameters
+// Validate token and filename to prevent path traversal
+const safePathSegment = z.string().min(1).refine(
+    (value) => !value.includes("../") && !value.includes("..\\") && !value.includes("/") && !value.includes("\\"),
+    { message: "Invalid path segment" }
+);
+
 const NoteImageRequestSchema = z.object({
     brainId: z.string().uuid(),
-    token: z.string().min(1),
-    filename: z.string().min(1)
+    token: safePathSegment,
+    filename: safePathSegment
 });
 
 export class NotesImagesApi {
@@ -23,7 +29,7 @@ export class NotesImagesApi {
         const params = NoteImageRequestSchema.parse({ brainId, token, filename });
         
         const response = await this.axiosInstance.get(
-            `/notes-images/${params.brainId}/${params.token}/${params.filename}`,
+            `/notes-images/${encodeURIComponent(params.brainId)}/${encodeURIComponent(params.token)}/${encodeURIComponent(params.filename)}`,
             {
                 responseType: 'arraybuffer'
             }
@@ -50,4 +56,4 @@ export class NotesImagesApi {
         const base64 = Buffer.from(imageData).toString('base64');
         return `data:${mimeType};base64,${base64}`;
     }
-} 
+}


### PR DESCRIPTION
## Summary
- encode note image request parts in URLs
- guard against path traversal in token and filename
- test encoded note image retrieval and validation

## Testing
- `yarn test src/__tests__/mocked/notes-images.test.ts`
- `yarn test` *(fails: THEBRAIN_API_KEY environment variable is required for running end-to-end tests)*
- `yarn lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_68b534e2e08883258c53b7fd8a2fbd83