### PR TITLE
Return array for organization members

### DIFF
--- a/src/__tests__/e2e/users.e2e.test.ts
+++ b/src/__tests__/e2e/users.e2e.test.ts
@@ -15,8 +15,10 @@ describe('Users API E2E', () => {
     describe('Organization Members', () => {
         it('should get organization members', async () => {
             try {
-                const member = await api.users.getOrganizationMembers();
-                expect(member).toBeDefined();
+                const members = await api.users.getOrganizationMembers();
+                expect(Array.isArray(members)).toBe(true);
+                expect(members.length).toBeGreaterThan(0);
+                const member = members[0];
                 expect(member.id).toBeDefined();
                 expect(typeof member.emailAddress).toBe('string');
             } catch (error: any) {

--- a/src/__tests__/mocked/users.test.ts
+++ b/src/__tests__/mocked/users.test.ts
@@ -8,15 +8,17 @@ describe('UsersApi', () => {
     let mock: MockAdapter;
     let api: UsersApi;
 
-    const mockUser: UserDto = {
-        id: '123e4567-e89b-12d3-a456-426614174000',
-        username: 'johndoe',
-        lastName: 'Doe',
-        firstName: 'John',
-        emailAddress: 'john.doe@example.com',
-        servicesExpiry: '2024-12-31T23:59:59Z',
-        accountType: 'premium'
-    };
+    const mockUsers: UserDto[] = [
+        {
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            username: 'johndoe',
+            lastName: 'Doe',
+            firstName: 'John',
+            emailAddress: 'john.doe@example.com',
+            servicesExpiry: '2024-12-31T23:59:59Z',
+            accountType: 'premium'
+        }
+    ];
 
     beforeEach(() => {
         const instance = axios.create();
@@ -31,29 +33,17 @@ describe('UsersApi', () => {
 
     describe('getOrganizationMembers', () => {
         it('should get organization members', async () => {
-            mock.onGet('/users/organization')
-                .reply(200, mockUser);
+            mock.onGet('/users/organization').reply(200, mockUsers);
 
             const result = await api.getOrganizationMembers();
-            expect(result).toEqual(mockUser);
+            expect(result).toEqual(mockUsers);
         });
 
         it('should handle empty response', async () => {
-            const emptyUser: UserDto = {
-                id: '123e4567-e89b-12d3-a456-426614174000',
-                username: null,
-                lastName: null,
-                firstName: null,
-                emailAddress: null,
-                servicesExpiry: null,
-                accountType: null
-            };
-
-            mock.onGet('/users/organization')
-                .reply(200, emptyUser);
+            mock.onGet('/users/organization').reply(200, []);
 
             const result = await api.getOrganizationMembers();
-            expect(result).toEqual(emptyUser);
+            expect(result).toEqual([]);
         });
 
         it('should handle server error', async () => {

--- a/src/users.ts
+++ b/src/users.ts
@@ -5,10 +5,10 @@ export class UsersApi {
     constructor(private readonly axios: AxiosInstance) {}
 
     /**
-     * Returns details about the active user's TeamBrain Organization members
+     * Returns an array of details about the active user's TeamBrain Organization members
      */
-    async getOrganizationMembers(): Promise<UserDto> {
-        const response = await this.axios.get<UserDto>("/users/organization");
+    async getOrganizationMembers(): Promise<UserDto[]> {
+        const response = await this.axios.get<UserDto[]>("/users/organization");
         return response.data;
     }
-} 
+}


### PR DESCRIPTION
## Summary
- return array of organization members from UsersApi
- update Users API tests to use arrays

## Testing
- `yarn test` (fails: THEBRAIN_API_KEY environment variable is required)
- `yarn test src/__tests__/mocked/users.test.ts`
- `yarn lint` (fails: ESLint couldn't find a configuration file)

------
https://chatgpt.com/codex/tasks/task_b_68b53606706c832596699941756f762f