### PR TITLE
Let Axios set multipart boundary when creating brains

### DIFF
--- a/src/__tests__/integration/create-brain.integration.test.ts
+++ b/src/__tests__/integration/create-brain.integration.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import axios from 'axios';
+import { BrainsApi } from '../../brains';
+import http from 'http';
+
+describe('createBrain integration', () => {
+    it('should upload form data with boundary automatically set', async () => {
+        let capturedHeaders: http.IncomingHttpHeaders | undefined;
+        let body = '';
+
+        const server = http.createServer((req, res) => {
+            capturedHeaders = req.headers;
+            req.setEncoding('utf8');
+            req.on('data', chunk => {
+                body += chunk;
+            });
+            req.on('end', () => {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(
+                    JSON.stringify([
+                        { id: '1', name: 'Integration Brain', homeThoughtId: '2' },
+                    ])
+                );
+            });
+        });
+
+        await new Promise<void>(resolve => server.listen(0, resolve));
+        const port = (server.address() as any).port;
+
+        const axiosInstance = axios.create({ baseURL: `http://localhost:${port}` });
+        const api = new BrainsApi(axiosInstance);
+        const response = await api.createBrain('Integration Brain');
+
+        expect(response).toEqual([
+            { id: '1', name: 'Integration Brain', homeThoughtId: '2' },
+        ]);
+        expect(capturedHeaders?.['content-type']).toMatch(/multipart\/form-data; boundary=/);
+        expect(body).toContain('Integration Brain');
+
+        server.close();
+    });
+});

--- a/src/brains.ts
+++ b/src/brains.ts
@@ -69,11 +69,7 @@ export class BrainsApi {
     async createBrain(brainName: string): Promise<BrainDto[]> {
         const formData = new FormData();
         formData.append('brainName', brainName);
-        const { data } = await this.axios.post<BrainDto[]>('/brains', formData, {
-            headers: {
-                'Content-Type': 'multipart/form-data',
-            },
-        });
+        const { data } = await this.axios.post<BrainDto[]>('/brains', formData);
         return data;
     }
 


### PR DESCRIPTION
## Summary
- rely on Axios/FormData to set `Content-Type` for `createBrain`
- add integration test to ensure multipart upload succeeds and includes boundary

## Testing
- `npm test` *(fails: THEBRAIN_API_KEY environment variable is required for running end-to-end tests)*
- `npx vitest run src/__tests__/integration/create-brain.integration.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68b53788c5ac8325808beed2ccc96ae4