### PR TITLE
Handle optional name for URL attachments

### DIFF
--- a/src/__tests__/mocked/attachments.test.ts
+++ b/src/__tests__/mocked/attachments.test.ts
@@ -146,23 +146,27 @@ describe('AttachmentsApi', () => {
     describe('addUrlAttachment', () => {
         it('should add URL attachment without name', async () => {
             const url = 'https://example.com/test.pdf';
-            mock.onPost(`/attachments/${mockBrainId}/${mockThoughtId}/url`).reply(200);
+            let receivedParams: any;
+            mock.onPost(`/attachments/${mockBrainId}/${mockThoughtId}/url`).reply((config) => {
+                receivedParams = config.params;
+                return [200];
+            });
 
-            await expect(api.addUrlAttachment(mockBrainId, mockThoughtId, url))
-                .resolves
-                .not
-                .toThrow();
+            await api.addUrlAttachment(mockBrainId, mockThoughtId, url);
+            expect(receivedParams).toEqual({ url });
         });
 
         it('should add URL attachment with name', async () => {
             const url = 'https://example.com/test.pdf';
             const name = 'Custom Name';
-            mock.onPost(`/attachments/${mockBrainId}/${mockThoughtId}/url`).reply(200);
+            let receivedParams: any;
+            mock.onPost(`/attachments/${mockBrainId}/${mockThoughtId}/url`).reply((config) => {
+                receivedParams = config.params;
+                return [200];
+            });
 
-            await expect(api.addUrlAttachment(mockBrainId, mockThoughtId, url, name))
-                .resolves
-                .not
-                .toThrow();
+            await api.addUrlAttachment(mockBrainId, mockThoughtId, url, name);
+            expect(receivedParams).toEqual({ url, name });
         });
 
         it('should throw error on invalid parameters', async () => {

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -31,11 +31,16 @@ export class AttachmentsApi {
     }
 
     async addUrlAttachment(brainId: string, thoughtId: string, url: string, name?: string): Promise<void> {
+        const params: { url?: string; name?: string } = {};
+        if (url !== undefined) {
+            params.url = url;
+        }
+        if (name !== undefined) {
+            params.name = name;
+        }
+
         await this.axiosInstance.post(`/attachments/${brainId}/${thoughtId}/url`, null, {
-            params: {
-                url,
-                name
-            }
+            params
         });
     }
-} 
+}


### PR DESCRIPTION
## Summary
- build URL attachment params object using only defined values
- test that addUrlAttachment omits name when none supplied

## Testing
- `yarn lint` *(fails: ESLint couldn't find a configuration file)*
- `yarn test` *(fails: THEBRAIN_API_KEY environment variable is required for running end-to-end tests)*
- `yarn test src/__tests__/mocked/attachments.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68b61555b5848325b8ed4e7a907335c6