### PR TITLE
Allow custom Axios options in TheBrain API config

### DIFF
--- a/src/__tests__/axios-options.test.ts
+++ b/src/__tests__/axios-options.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import axios, { AxiosInstance } from 'axios';
+import { TheBrainApi } from '../index';
+
+describe('TheBrainApi Axios options', () => {
+    it('preserves extra axios configuration like headers and timeout', () => {
+        const createSpy = vi.spyOn(axios, 'create');
+
+        const fakeInstance = {
+            interceptors: {
+                request: { use: vi.fn() },
+                response: { use: vi.fn() },
+            },
+        } as unknown as AxiosInstance;
+
+        createSpy.mockReturnValue(fakeInstance);
+
+        new TheBrainApi({
+            apiKey: 'key',
+            headers: { 'X-Test': 'value' },
+            timeout: 1234,
+        });
+
+        expect(createSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                timeout: 1234,
+                headers: expect.objectContaining({
+                    'X-Test': 'value',
+                    Authorization: 'Bearer key',
+                }),
+            })
+        );
+
+        createSpy.mockRestore();
+    });
+});
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,15 +11,23 @@ import { UsersApi } from "./users";
 import { ThoughtsApi } from "./thoughts";
 import logger from "./logger";
 
-const ConfigSchema = z.object({
-    apiKey: z.string().min(1, "API key is required"),
-    requestLimit: z.number().default(10),
-    rateLimitWindows: z.number().default(1000),
-    baseURL: z.string().default("https://api.bra.in"),
-    logLevel: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).optional(),
-})
+const ConfigSchema = z
+    .object({
+        apiKey: z.string().min(1, "API key is required"),
+        requestLimit: z.number().default(10),
+        rateLimitWindows: z.number().default(1000),
+        baseURL: z.string().default("https://api.bra.in"),
+        logLevel: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).optional(),
+    })
+    .passthrough();
 
-export type BrainAPIConfig = z.infer<typeof ConfigSchema> & Omit<AxiosRequestConfig, keyof z.infer<typeof ConfigSchema>>;
+export type BrainAPIConfig = AxiosRequestConfig & {
+    apiKey: string;
+    requestLimit?: number;
+    rateLimitWindows?: number;
+    baseURL?: string;
+    logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+};
 
 export class TheBrainApi {
     private readonly axios: AxiosInstance;


### PR DESCRIPTION
## Summary
- allow unknown config keys to pass through via `zod.passthrough`
- type config to accept additional Axios options
- test that headers and timeout passed to constructor are used in `axios.create`

## Testing
- `yarn test` *(fails: THEBRAIN_API_KEY environment variable is required for running end-to-end tests)*
- `yarn test src/__tests__/axios-options.test.ts src/__tests__/logger.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68b622093b888325baefa9f8c84d354e