### PR TITLE
fix: allow automatic boundary for file uploads

### DIFF
--- a/src/__tests__/integration/attachments.integration.test.ts
+++ b/src/__tests__/integration/attachments.integration.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import axios from 'axios';
+import { AttachmentsApi } from '../../attachments';
+import http from 'http';
+
+// Integration test to ensure automatic boundary for file uploads
+
+describe('addFileAttachment integration', () => {
+    it('should upload file with boundary automatically set', async () => {
+        let capturedHeaders: http.IncomingHttpHeaders | undefined;
+        let body = '';
+
+        const server = http.createServer((req, res) => {
+            capturedHeaders = req.headers;
+            req.setEncoding('utf8');
+            req.on('data', chunk => {
+                body += chunk;
+            });
+            req.on('end', () => {
+                res.writeHead(200);
+                res.end('OK');
+            });
+        });
+
+        await new Promise<void>(resolve => server.listen(0, resolve));
+        const port = (server.address() as any).port;
+
+        const axiosInstance = axios.create({ baseURL: `http://localhost:${port}` });
+        const api = new AttachmentsApi(axiosInstance);
+        const testFile = new File(['test file content'], 'test.txt', { type: 'text/plain' });
+
+        await api.addFileAttachment('brain', 'thought', testFile);
+
+        expect(capturedHeaders?.['content-type']).toMatch(/multipart\/form-data; boundary=/);
+        expect(body).toContain('test.txt');
+        expect(body).toContain('test file content');
+
+        server.close();
+    });
+});

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -23,11 +23,7 @@ export class AttachmentsApi {
     async addFileAttachment(brainId: string, thoughtId: string, file: File): Promise<void> {
         const formData = new FormData();
         formData.append('file', file);
-        await this.axiosInstance.post(`/attachments/${brainId}/${thoughtId}/file`, formData, {
-            headers: {
-                'Content-Type': 'multipart/form-data'
-            }
-        });
+        await this.axiosInstance.post(`/attachments/${brainId}/${thoughtId}/file`, formData);
     }
 
     async addUrlAttachment(brainId: string, thoughtId: string, url: string, name?: string): Promise<void> {


### PR DESCRIPTION
## Summary
- remove manual `Content-Type` header from `addFileAttachment`
- add integration test to ensure uploads include an automatic multipart boundary

## Testing
- `yarn test src/__tests__/e2e/attachments.e2e.test.ts` *(fails: THEBRAIN_API_KEY environment variable is required)*
- `npx vitest run src/__tests__/mocked/attachments.test.ts src/__tests__/integration/attachments.integration.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68b6255a7568832588d8fe4cc823e6d0