### PR TITLE
chore: require Node 18 and skip e2e tests without API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A TypeScript client for TheBrain API that provides type-safe access to all API endpoints.
 
 ## Installation
+Requires **Node.js 18** or later.
 
 ```bash
 yarn add thebrain-api

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "vitest": "^3.1"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/e2e/attachments.e2e.test.ts
+++ b/src/__tests__/e2e/attachments.e2e.test.ts
@@ -8,7 +8,7 @@ let testThoughtId: string;
 let helper: TestHelper;
 let api: TheBrainApi;
 
-describe('Attachments API E2E', () => {
+describe.skipIf(!process.env.THEBRAIN_API_KEY)('Attachments API E2E', () => {
     beforeAll(async () => {
         helper = new TestHelper();
         api = helper.api;

--- a/src/__tests__/e2e/brain-access.e2e.test.ts
+++ b/src/__tests__/e2e/brain-access.e2e.test.ts
@@ -8,7 +8,7 @@ let testBrainId: string;
 let helper: TestHelper;
 let api: TheBrainApi;
 
-describe('Brain Access API E2E', () => {
+describe.skipIf(!process.env.THEBRAIN_API_KEY)('Brain Access API E2E', () => {
     beforeAll(async () => {
         helper = new TestHelper();
         api = helper.api;

--- a/src/__tests__/e2e/brains.e2e.test.ts
+++ b/src/__tests__/e2e/brains.e2e.test.ts
@@ -6,7 +6,7 @@ let testBrainId: string;
 let helper: TestHelper;
 let api: TheBrainApi;
 
-describe('Brains API E2E', () => {
+describe.skipIf(!process.env.THEBRAIN_API_KEY)('Brains API E2E', () => {
     beforeAll(async () => {
         helper = new TestHelper();
         api = helper.api;

--- a/src/__tests__/e2e/get-brains.e2e.test.ts
+++ b/src/__tests__/e2e/get-brains.e2e.test.ts
@@ -2,7 +2,7 @@ import { describe, it, beforeAll, expect } from 'vitest';
 import { TheBrainApi } from '../../index';
 import { loadConfig } from './config';
 
-describe('Get Brains API E2E Test', () => {
+describe.skipIf(!process.env.THEBRAIN_API_KEY)('Get Brains API E2E Test', () => {
     let api: TheBrainApi;
 
     beforeAll(async () => {

--- a/src/__tests__/e2e/links.e2e.test.ts
+++ b/src/__tests__/e2e/links.e2e.test.ts
@@ -9,7 +9,7 @@ let targetThoughtId: string;
 let helper: TestHelper;
 let api: TheBrainApi;
 
-describe('Links API E2E', () => {
+describe.skipIf(!process.env.THEBRAIN_API_KEY)('Links API E2E', () => {
     beforeAll(async () => {
         helper = new TestHelper();
         api = helper.api;

--- a/src/__tests__/e2e/notes-images.e2e.test.ts
+++ b/src/__tests__/e2e/notes-images.e2e.test.ts
@@ -8,7 +8,7 @@ let testThoughtId: string;
 let helper: TestHelper;
 let api: TheBrainApi;
 
-describe('Notes Images API E2E', () => {
+describe.skipIf(!process.env.THEBRAIN_API_KEY)('Notes Images API E2E', () => {
     beforeAll(async () => {
         helper = new TestHelper();
         api = helper.api;

--- a/src/__tests__/e2e/notes.e2e.test.ts
+++ b/src/__tests__/e2e/notes.e2e.test.ts
@@ -8,7 +8,7 @@ let testThoughtId: string;
 let helper: TestHelper;
 let api: TheBrainApi;
 
-describe('Notes API E2E', () => {
+describe.skipIf(!process.env.THEBRAIN_API_KEY)('Notes API E2E', () => {
     beforeAll(async () => {
         helper = new TestHelper();
         api = helper.api;

--- a/src/__tests__/e2e/search.e2e.test.ts
+++ b/src/__tests__/e2e/search.e2e.test.ts
@@ -7,7 +7,7 @@ let testBrainId: string;
 let helper: TestHelper;
 let api: TheBrainApi;
 
-describe('Search API E2E', () => {
+describe.skipIf(!process.env.THEBRAIN_API_KEY)('Search API E2E', () => {
     beforeAll(async () => {
         // Initialize API and create test resources
         helper = new TestHelper();

--- a/src/__tests__/e2e/thoughts.e2e.test.ts
+++ b/src/__tests__/e2e/thoughts.e2e.test.ts
@@ -11,7 +11,7 @@ let helper: TestHelper;
 let api: TheBrainApi;
 let brain: BrainDto;
 
-describe('Thoughts API E2E', () => {
+describe.skipIf(!process.env.THEBRAIN_API_KEY)('Thoughts API E2E', () => {
     beforeAll(async () => {
         helper = new TestHelper();
         api = helper.api;

--- a/src/__tests__/e2e/users.e2e.test.ts
+++ b/src/__tests__/e2e/users.e2e.test.ts
@@ -6,7 +6,7 @@ import { UserDto } from '../../model';
 let helper: TestHelper;
 let api: TheBrainApi;
 
-describe('Users API E2E', () => {
+describe.skipIf(!process.env.THEBRAIN_API_KEY)('Users API E2E', () => {
     beforeAll(async () => {
         helper = new TestHelper();
         api = helper.api;


### PR DESCRIPTION
## Summary
- require Node.js v18+ in package.json
- document Node 18 requirement in README
- skip E2E tests when THEBRAIN_API_KEY is absent

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(warnings: missing type declarations and implicit any)*

------
https://chatgpt.com/codex/tasks/task_b_68b6279f7b408325aa38c8b0f9b293ed