### PR TITLE
fix: map numeric log levels to names

### DIFF
--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import logger from '../logger';
+import { TheBrainApi } from '../index';
 
 describe('sanitizeHeaders', () => {
     it('redacts sensitive headers regardless of case', () => {
@@ -16,6 +17,15 @@ describe('sanitizeHeaders', () => {
         expect(serialized.headers.cOoKiE).toBe('[REDACTED]');
         expect(serialized.headers['SeT-CooKiE']).toBe('[REDACTED]');
         expect(serialized.headers['X-Custom']).toBe('value');
+    });
+});
+
+describe('getLogLevel', () => {
+    it('returns the current log level as a string', () => {
+        const api = new TheBrainApi({ apiKey: 'test' } as any);
+        api.setLogLevel('error');
+        expect(api.getLogLevel()).toBe('error');
+        api.setLogLevel('info');
     });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { SearchApi } from "./search";
 import { UsersApi } from "./users";
 import { ThoughtsApi } from "./thoughts";
 import logger from "./logger";
+import bunyan from "bunyan";
 
 const ConfigSchema = z
     .object({
@@ -149,6 +150,10 @@ export class TheBrainApi {
      * Get the current logging level
      */
     public getLogLevel(): string {
-        return logger.level();
+        const level = logger.level();
+        if (typeof level === 'number') {
+            return bunyan.nameFromLevel[level] ?? level.toString();
+        }
+        return level;
     }
 }


### PR DESCRIPTION
## Summary
- convert numeric bunyan levels to their string names in `getLogLevel`
- add unit test ensuring `getLogLevel` returns the current log level name

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_68b62a7964788325bf4ab115854c6462