### PR TITLE
feat: support browser base64 for notes images

### DIFF
--- a/src/__tests__/notes-images.test.ts
+++ b/src/__tests__/notes-images.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { AxiosInstance } from 'axios';
+import { NotesImagesApi } from '../notes-images';
+
+describe('NotesImagesApi.getNoteImageAsDataUrl', () => {
+    const text = 'test data';
+    const arrayBuffer = new TextEncoder().encode(text).buffer;
+    const expected = `data:image/png;base64,${Buffer.from(text).toString('base64')}`;
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('encodes using Buffer in Node environment', async () => {
+        const bufferSpy = vi.spyOn(Buffer, 'from');
+        vi.spyOn(NotesImagesApi.prototype, 'getNoteImage').mockResolvedValue(arrayBuffer);
+
+        const api = new NotesImagesApi({} as AxiosInstance);
+        const result = await api.getNoteImageAsDataUrl('b', 't', 'f', 'image/png');
+
+        expect(result).toBe(expected);
+        expect(bufferSpy).toHaveBeenCalled();
+    });
+
+    it('encodes using btoa in browser environment', async () => {
+        const bufferSpy = vi.spyOn(Buffer, 'from');
+        const btoaSpy = vi.fn((str: string) => Buffer.from(str, 'binary').toString('base64'));
+        (globalThis as any).window = {};
+        (globalThis as any).btoa = btoaSpy;
+        vi.spyOn(NotesImagesApi.prototype, 'getNoteImage').mockResolvedValue(arrayBuffer);
+
+        const api = new NotesImagesApi({} as AxiosInstance);
+        const result = await api.getNoteImageAsDataUrl('b', 't', 'f', 'image/png');
+
+        expect(result).toBe(expected);
+        expect(btoaSpy).toHaveBeenCalled();
+        // Should only call Buffer.from via our btoa implementation
+        expect(bufferSpy).toHaveBeenCalledTimes(1);
+
+        delete (globalThis as any).window;
+        delete (globalThis as any).btoa;
+    });
+});
+

--- a/src/notes-images.ts
+++ b/src/notes-images.ts
@@ -47,13 +47,26 @@ export class NotesImagesApi {
      * @returns A base64 data URL that can be used in an img tag's src attribute
      */
     async getNoteImageAsDataUrl(
-        brainId: string, 
-        token: string, 
+        brainId: string,
+        token: string,
         filename: string,
         mimeType: string
     ): Promise<string> {
         const imageData = await this.getNoteImage(brainId, token, filename);
-        const base64 = Buffer.from(imageData).toString('base64');
+        // Detect environment: use Buffer in Node.js, otherwise use browser APIs
+        let base64: string;
+        if (typeof window === 'undefined') {
+            // Node.js environment
+            base64 = Buffer.from(imageData).toString('base64');
+        } else {
+            // Browser environment
+            const bytes = new Uint8Array(imageData);
+            let binary = '';
+            for (let i = 0; i < bytes.byteLength; i++) {
+                binary += String.fromCharCode(bytes[i]);
+            }
+            base64 = btoa(binary);
+        }
         return `data:${mimeType};base64,${base64}`;
     }
 }


### PR DESCRIPTION
## Summary
- handle base64 conversion for note images in both Node.js and browsers
- add tests for Node and simulated browser environments

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_68b62cf5c4708325a0c11d6d670ffada