### PR TITLE
refactor: remove redundant DTO schemas

### DIFF
--- a/src/brains.ts
+++ b/src/brains.ts
@@ -1,57 +1,9 @@
 import { AxiosInstance } from "axios";
-import { z } from "zod";
-
-// Schemas
-export const BrainDto = z
-  .object({
-    id: z.string().uuid(),
-    name: z.string().nullable(),
-    homeThoughtId: z.string().uuid(),
-  })
-  .partial();
-
-export const StatisticsDto = z.object({
-  brainName: z.string().nullable(),
-  dateGenerated: z.string().datetime(),
-  brainId: z.string().uuid(),
-  thoughts: z.number(),
-  forgottenThoughts: z.number(),
-  links: z.number(),
-  linksPerThought: z.number(),
-  thoughtTypes: z.number(),
-  linkTypes: z.number(),
-  tags: z.number(),
-  notes: z.number(),
-  internalFiles: z.number(),
-  internalFolders: z.number(),
-  externalFiles: z.number(),
-  externalFolders: z.number(),
-  webLinks: z.number(),
-  assignedIcons: z.number(),
-  internalFilesSize: z.number(),
-  iconsFilesSize: z.number(),
-});
-
-export const ModificationLogDto = z.object({
-  sourceId: z.string().uuid(),
-  sourceType: z.number(),
-  extraAId: z.string().uuid().optional(),
-  extraAType: z.number().optional(),
-  extraBId: z.string().uuid().optional(),
-  extraBType: z.number().optional(),
-  modType: z.number(),
-  oldValue: z.string().nullable(),
-  newValue: z.string().nullable(),
-  userId: z.string().uuid(),
-  brainId: z.string().uuid(),
-  creationDateTime: z.string().datetime(),
-  modificationDateTime: z.string().datetime(),
-  syncUpdateDateTime: z.string().datetime().nullable(),
-});
-
-export type BrainDto = z.infer<typeof BrainDto>;
-export type StatisticsDto = z.infer<typeof StatisticsDto>;
-export type ModificationLogDto = z.infer<typeof ModificationLogDto>;
+import type {
+  BrainDto,
+  StatisticsDto,
+  ModificationLogDto,
+} from "./model";
 
 export class BrainsApi {
     constructor(private readonly axios: AxiosInstance) {}


### PR DESCRIPTION
## Summary
- remove duplicate DTO schema definitions in `brains.ts`
- import shared DTO types from `model.ts`

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_b_68b62f0a651c832591407801f05e15a2