### PR TITLE
feat: add params serializer for search

### DIFF
--- a/src/__tests__/mocked/search.test.ts
+++ b/src/__tests__/mocked/search.test.ts
@@ -119,6 +119,24 @@ describe('SearchApi', () => {
             expect(result).toEqual([mockSearchResult]);
         });
 
+        it('serializes excluded brain IDs correctly in the request URL', async () => {
+            const options = {
+                excludeBrainIds: [
+                    '11111111-1111-1111-1111-111111111111',
+                    '22222222-2222-2222-2222-222222222222'
+                ]
+            };
+
+            mock.onGet('/search/public').reply(200, [mockSearchResult]);
+
+            await api.searchPublic(mockQueryText, options);
+
+            const config = mock.history.get[0];
+            const serialized = config.paramsSerializer.serialize(config.params);
+            const params = new URLSearchParams(serialized);
+            expect(params.getAll('excludeBrainIds')).toEqual(options.excludeBrainIds);
+        });
+
         it('should throw error on invalid parameters', async () => {
             const invalidOptions = {
                 excludeBrainIds: ['invalid-uuid']

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,6 +1,22 @@
 import { AxiosInstance } from "axios";
 import { SearchResultDto } from "./model";
 
+const paramsSerializer = (params: Record<string, any>): string => {
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === null) continue;
+        if (Array.isArray(value)) {
+            if (value.length === 0) continue;
+            for (const v of value) {
+                searchParams.append(key, v);
+            }
+        } else {
+            searchParams.append(key, String(value));
+        }
+    }
+    return searchParams.toString();
+};
+
 export interface SearchOptions {
     maxResults?: number;
     onlySearchThoughtNames?: boolean;
@@ -20,7 +36,8 @@ export class SearchApi {
                 queryText,
                 maxResults,
                 onlySearchThoughtNames
-            }
+            },
+            paramsSerializer
         });
         return response.data;
     }
@@ -36,7 +53,8 @@ export class SearchApi {
                 maxResults,
                 onlySearchThoughtNames,
                 excludeBrainIds
-            }
+            },
+            paramsSerializer
         });
         return response.data;
     }
@@ -51,7 +69,8 @@ export class SearchApi {
                 queryText,
                 maxResults,
                 onlySearchThoughtNames
-            }
+            },
+            paramsSerializer
         });
         return response.data;
     }


### PR DESCRIPTION
## Summary
- ensure search API serializes array params without brackets
- test that excluded brain IDs are correctly represented in request URL

## Testing
- `yarn test`
- `yarn lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_68b6330faa348325b700a99e0729c6f8