### PR TITLE
refactor: make BrainDto fields required

### DIFF
--- a/src/__tests__/e2e/attachments.e2e.test.ts
+++ b/src/__tests__/e2e/attachments.e2e.test.ts
@@ -16,7 +16,7 @@ describe.skipIf(!process.env.THEBRAIN_API_KEY)('Attachments API E2E', () => {
         
         // Create a test brain
         const brain = await helper.createTestBrain('Test Brain Attachments E2E');
-        testBrainId = brain.id!;
+        testBrainId = brain.id;
 
         // Create a test thought
         const thought = await api.thoughts.createThought(testBrainId, {

--- a/src/__tests__/e2e/brain-access.e2e.test.ts
+++ b/src/__tests__/e2e/brain-access.e2e.test.ts
@@ -16,7 +16,7 @@ describe.skipIf(!process.env.THEBRAIN_API_KEY)('Brain Access API E2E', () => {
         
         // Create a test brain
         const brain = await helper.createTestBrain('Test Brain Access E2E');
-        testBrainId = brain.id!;
+        testBrainId = brain.id;
     });
 
     afterAll(async () => {

--- a/src/__tests__/e2e/brains.e2e.test.ts
+++ b/src/__tests__/e2e/brains.e2e.test.ts
@@ -14,7 +14,7 @@ describe.skipIf(!process.env.THEBRAIN_API_KEY)('Brains API E2E', () => {
         
         // Create a test brain
         const brain = await helper.createTestBrain('Test Brain E2E');
-        testBrainId = brain.id!;
+        testBrainId = brain.id;
     });
 
     afterAll(async () => {

--- a/src/__tests__/e2e/helpers.ts
+++ b/src/__tests__/e2e/helpers.ts
@@ -23,12 +23,10 @@ export class TestHelper {
             // First check if a brain with this name already exists
             const existingBrains = await this.api.brains.getBrains();
             const existingBrain = existingBrains.find(brain => brain.name === name);
-            
+
             if (existingBrain) {
                 console.log(`Found existing brain with name "${name}" (ID: ${existingBrain.id})`);
-                if (existingBrain.id) {
-                    this.testBrains.push(existingBrain);
-                }
+                this.testBrains.push(existingBrain);
                 return existingBrain;
             }
 
@@ -40,7 +38,7 @@ export class TestHelper {
             } else if (brains && typeof brains === 'object') {
                 brain = brains;
             }
-            if (!brain || !brain.id) {
+            if (!brain) {
                 throw new Error('Created brain has no ID');
             }
 
@@ -61,7 +59,6 @@ export class TestHelper {
     async cleanup(): Promise<void> {
         // Delete all test brains in reverse order to avoid potential dependency issues
         for (const brain of this.testBrains.reverse()) {
-            if (!brain.id) continue;
             try {
                 await this.api.brains.deleteBrain(brain.id);
                 console.log(`Successfully deleted test brain ${brain.id}`);
@@ -71,4 +68,4 @@ export class TestHelper {
         }
         this.testBrains = [];
     }
-} 
+}

--- a/src/__tests__/e2e/links.e2e.test.ts
+++ b/src/__tests__/e2e/links.e2e.test.ts
@@ -17,7 +17,7 @@ describe.skipIf(!process.env.THEBRAIN_API_KEY)('Links API E2E', () => {
         
         // Create a test brain
         const brain = await helper.createTestBrain('Test Brain Links E2E');
-        testBrainId = brain.id!;
+        testBrainId = brain.id;
 
         // Create source thought
         const sourceThought = await api.thoughts.createThought(testBrainId, {

--- a/src/__tests__/e2e/notes-images.e2e.test.ts
+++ b/src/__tests__/e2e/notes-images.e2e.test.ts
@@ -16,7 +16,7 @@ describe.skipIf(!process.env.THEBRAIN_API_KEY)('Notes Images API E2E', () => {
         
         // Create a test brain
         const brain = await helper.createTestBrain('Test Brain Notes Images E2E');
-        testBrainId = brain.id!;
+        testBrainId = brain.id;
 
         // Create a test thought
         const thought = await api.thoughts.createThought(testBrainId, {

--- a/src/__tests__/e2e/notes.e2e.test.ts
+++ b/src/__tests__/e2e/notes.e2e.test.ts
@@ -16,7 +16,7 @@ describe.skipIf(!process.env.THEBRAIN_API_KEY)('Notes API E2E', () => {
         
         // Create a test brain
         const brain = await helper.createTestBrain('Test Brain Notes E2E');
-        testBrainId = brain.id!;
+        testBrainId = brain.id;
 
         // Create a test thought
         const thought = await api.thoughts.createThought(testBrainId, {

--- a/src/__tests__/e2e/search.e2e.test.ts
+++ b/src/__tests__/e2e/search.e2e.test.ts
@@ -16,7 +16,7 @@ describe.skipIf(!process.env.THEBRAIN_API_KEY)('Search API E2E', () => {
         
         // Create a test brain for search testing
         const brain = await helper.createTestBrain('Test Brain Search E2E');
-        testBrainId = brain.id!;
+        testBrainId = brain.id;
         console.log('Created test brain for search testing:', testBrainId);
         
         // Create a test thought with searchable content

--- a/src/__tests__/e2e/thoughts.e2e.test.ts
+++ b/src/__tests__/e2e/thoughts.e2e.test.ts
@@ -18,7 +18,7 @@ describe.skipIf(!process.env.THEBRAIN_API_KEY)('Thoughts API E2E', () => {
         api = helper.api;
         // Create a test brain
         const brain = await helper.createTestBrain('Test Brain E2E');
-        testBrainId = brain.id!;
+        testBrainId = brain.id;
 
         const thought = await api.thoughts.createThought(testBrainId, {
             name: 'Test Thought',

--- a/src/model.ts
+++ b/src/model.ts
@@ -99,7 +99,7 @@ const BaseModificationModel = z.object({
 export const BrainDto = BaseEntitySchema.extend({
     name: z.string().nullable(),
     homeThoughtId: z.string().uuid(),
-}).partial();
+});
 
 export const BrainAccessorDto = z.object({
     accessorId: z.string().uuid(),


### PR DESCRIPTION
## Summary
- remove partial on BrainDto to enforce required fields
- clean up test helpers and e2e tests to treat brain IDs as required

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_68b644f8780483259e9d257f932549cb