### PR TITLE
feat: support arraybuffer attachments

### DIFF
--- a/src/__tests__/mocked/attachments.test.ts
+++ b/src/__tests__/mocked/attachments.test.ts
@@ -66,16 +66,17 @@ describe('AttachmentsApi', () => {
     });
 
     describe('getAttachmentContent', () => {
-        it('should get attachment content as blob', async () => {
-            const mockBlob = new Blob(['test content'], { type: 'application/pdf' });
+        it('should get attachment content', async () => {
+            const mockArrayBuffer = new TextEncoder().encode('test content').buffer;
             mock.onGet(`/attachments/${mockBrainId}/${mockAttachmentId}/file-content`)
-                .reply(200, mockBlob, {
+                .reply(200, mockArrayBuffer, {
                     'content-type': 'application/pdf'
                 });
 
             const result = await api.getAttachmentContent(mockBrainId, mockAttachmentId);
-            expect(result).toBeInstanceOf(Blob);
-            expect(result.type).toBe('application/pdf');
+            const isBlob = typeof Blob !== 'undefined' && result instanceof Blob;
+            const isArrayBuffer = result instanceof ArrayBuffer;
+            expect(isBlob || isArrayBuffer).toBe(true);
         });
 
         it('should throw error on invalid parameters', async () => {

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -24,11 +24,11 @@ export class AttachmentsApi {
      * @param brainId Brain identifier containing the attachment.
      * @param attachmentId Identifier of the attachment to fetch.
      */
-    async getAttachmentContent(brainId: string, attachmentId: string): Promise<Blob> {
-        const response = await this.axiosInstance.get(`/attachments/${brainId}/${attachmentId}/file-content`, {
-            responseType: 'blob'
+    async getAttachmentContent(brainId: string, attachmentId: string): Promise<ArrayBuffer | Blob> {
+        const response = await this.axiosInstance.get<ArrayBuffer>(`/attachments/${brainId}/${attachmentId}/file-content`, {
+            responseType: 'arraybuffer'
         });
-        return response.data;
+        return response.data as ArrayBuffer | Blob;
     }
 
     /**


### PR DESCRIPTION
## Summary
- support arraybuffer download for attachment content
- update tests to accept arraybuffer or blob

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_b_68b645039ea08325ae879e2a84344795