### PR TITLE
feat: validate brain access removal options

### DIFF
--- a/src/__tests__/mocked/brain-access.test.ts
+++ b/src/__tests__/mocked/brain-access.test.ts
@@ -147,6 +147,28 @@ describe('BrainAccessApi', () => {
                 .rejects
                 .toThrow(/Provide either emailAddress or userId, but not both/);
         });
+
+        it('should reject invalid email address format', async () => {
+            const invalidAccess = {
+                emailAddress: 'not-an-email',
+                accessType: AccessType.Reader
+            };
+
+            await expect(api.setBrainAccessLevel(mockBrainId, invalidAccess as any))
+                .rejects
+                .toThrow();
+        });
+
+        it('should reject invalid userId format', async () => {
+            const invalidAccess = {
+                userId: 'not-a-uuid',
+                accessType: AccessType.Reader
+            };
+
+            await expect(api.setBrainAccessLevel(mockBrainId, invalidAccess as any))
+                .rejects
+                .toThrow();
+        });
     });
 
     describe('removeBrainAccess', () => {
@@ -189,6 +211,22 @@ describe('BrainAccessApi', () => {
             }))
                 .rejects
                 .toThrow(/Provide either emailAddress or userId, but not both/);
+        });
+
+        it('should reject invalid email address format', async () => {
+            await expect(api.removeBrainAccess(mockBrainId, {
+                emailAddress: 'not-an-email'
+            }))
+                .rejects
+                .toThrow();
+        });
+
+        it('should reject invalid userId format', async () => {
+            await expect(api.removeBrainAccess(mockBrainId, {
+                userId: 'not-a-uuid'
+            }))
+                .rejects
+                .toThrow();
         });
     });
 });

--- a/src/brain-access.ts
+++ b/src/brain-access.ts
@@ -30,6 +30,20 @@ const SetBrainAccessSchema = z.object({
 export type SetBrainAccess = z.infer<typeof SetBrainAccessSchema>;
 
 /**
+ * Schema used for removing access for a brain.
+ */
+const RemoveBrainAccessSchema = z.object({
+    emailAddress: z.string().email().optional(),
+    userId: z.string().uuid().optional()
+}).refine(data => !(data.emailAddress && data.userId), {
+    message: "Provide either emailAddress or userId, but not both",
+}).refine(data => data.emailAddress || data.userId, {
+    message: "Either emailAddress or userId must be provided",
+});
+
+export type RemoveBrainAccess = z.infer<typeof RemoveBrainAccessSchema>;
+
+/**
  * API client for administering user access to a brain.
  */
 export class BrainAccessApi {
@@ -64,18 +78,12 @@ export class BrainAccessApi {
      */
     async removeBrainAccess(
         brainId: string,
-        options: { emailAddress?: string; userId?: string }
+        options: RemoveBrainAccess
     ): Promise<void> {
-        const { emailAddress, userId } = options;
-        if (!emailAddress && !userId) {
-            throw new Error("Either emailAddress or userId must be provided");
-        }
-        if (emailAddress && userId) {
-            throw new Error("Provide either emailAddress or userId, but not both");
-        }
+        const validatedOptions = RemoveBrainAccessSchema.parse(options);
 
         await this.axiosInstance.delete(`/brain-access/${brainId}`, {
-            params: { emailAddress, userId }
+            params: validatedOptions
         });
     }
 }


### PR DESCRIPTION
## Summary
- validate brain access removal options with a new Zod schema
- ensure delete call uses validated removal options
- test invalid email and userId cases

## Testing
- `yarn lint` (fails: ESLint couldn't find a configuration file)
- `yarn test src/__tests__/mocked/brain-access.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68b64a5910d48325aaf8433c2329fd13