### PR TITLE
Ensure array params serialized as strings

### DIFF
--- a/src/__tests__/mocked/search.test.ts
+++ b/src/__tests__/mocked/search.test.ts
@@ -138,6 +138,21 @@ describe('SearchApi', () => {
             expect(params.getAll('excludeBrainIds')).toEqual(options.excludeBrainIds);
         });
 
+        it('serializes numeric array values correctly in the request URL', async () => {
+            const options = {
+                excludeBrainIds: [123, 456]
+            } as any;
+
+            mock.onGet('/search/public').reply(200, [mockSearchResult]);
+
+            await api.searchPublic(mockQueryText, options);
+
+            const config = mock.history.get[0];
+            const serialized = config.paramsSerializer.serialize(config.params);
+            const params = new URLSearchParams(serialized);
+            expect(params.getAll('excludeBrainIds')).toEqual(['123', '456']);
+        });
+
         it('should throw error on invalid parameters', async () => {
             const invalidOptions = {
                 excludeBrainIds: ['invalid-uuid']

--- a/src/search.ts
+++ b/src/search.ts
@@ -8,7 +8,7 @@ const paramsSerializer = (params: Record<string, any>): string => {
         if (Array.isArray(value)) {
             if (value.length === 0) continue;
             for (const v of value) {
-                searchParams.append(key, v);
+                searchParams.append(key, String(v));
             }
         } else {
             searchParams.append(key, String(value));


### PR DESCRIPTION
## Summary
- Convert array parameter values to strings before appending in paramsSerializer
- Test numeric array serialization to ensure values are stringified

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_68b64e741fa08325b2bd0dcf4fcef29d