### PR TITLE
chore: enforce positive request configuration

### DIFF
--- a/src/__tests__/config-validation.test.ts
+++ b/src/__tests__/config-validation.test.ts
@@ -3,13 +3,11 @@ import { describe, it, expect } from 'vitest';
 import { TheBrainApi } from '../index';
 
 describe('TheBrainApi configuration validation', () => {
-    it('rejects non-positive requestLimit', () => {
-        expect(() => new TheBrainApi({ apiKey: 'key', requestLimit: 0 } as any)).toThrow();
-        expect(() => new TheBrainApi({ apiKey: 'key', requestLimit: -1 } as any)).toThrow();
+    it.each([0, -1])('rejects non-positive requestLimit (%i)', (value) => {
+        expect(() => new TheBrainApi({ apiKey: 'key', requestLimit: value } as any)).toThrow();
     });
 
-    it('rejects non-positive rateLimitWindows', () => {
-        expect(() => new TheBrainApi({ apiKey: 'key', rateLimitWindows: 0 } as any)).toThrow();
-        expect(() => new TheBrainApi({ apiKey: 'key', rateLimitWindows: -100 } as any)).toThrow();
+    it.each([0, -100])('rejects non-positive rateLimitWindows (%i)', (value) => {
+        expect(() => new TheBrainApi({ apiKey: 'key', rateLimitWindows: value } as any)).toThrow();
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,9 @@ import bunyan from "bunyan";
 const ConfigSchema = z
     .object({
         apiKey: z.string().min(1, "API key is required"),
+        // Limit of requests allowed per rate limit window
         requestLimit: z.number().int().positive().default(10),
+        // Duration of the rate limit window in milliseconds
         rateLimitWindows: z.number().int().positive().default(1000),
         baseURL: z.string().default("https://api.bra.in"),
         logLevel: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).optional(),


### PR DESCRIPTION
## Summary
- ensure rate limiting config uses positive integer defaults
- test that zero and negative request settings throw validation errors

## Testing
- `yarn test src/__tests__/config-validation.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_68b651af86208325a41a22e9d954708f