### PR TITLE
chore: enforce thought type validations

### DIFF
--- a/src/thoughts.ts
+++ b/src/thoughts.ts
@@ -5,7 +5,11 @@ import {
     ThoughtCreateModel,
     ThoughtDtoOperation,
     ThoughtDtoJsonPatchDocument,
-    CreateThoughtResponseModel
+    CreateThoughtResponseModel,
+    AttachmentDto,
+    ModificationLogDto,
+    ThoughtGraphDto as ThoughtGraphDtoSchema,
+    type ThoughtGraphDto,
 } from "./model";
 
 /** API client for CRUD operations on thoughts within a brain. */
@@ -13,18 +17,18 @@ export class ThoughtsApi {
     constructor(private readonly axiosInstance: AxiosInstance) {}
 
     async getThoughts(brainId: string): Promise<ThoughtDto[]> {
-        const response = await this.axiosInstance.get(`/thoughts/${brainId}`);
-        return response.data;
+        const { data } = await this.axiosInstance.get<unknown>(`/thoughts/${brainId}`);
+        return ThoughtDto.array().parse(data);
     }
 
     async getThought(brainId: string, thoughtId: string): Promise<ThoughtDto> {
-        const response = await this.axiosInstance.get(`/thoughts/${brainId}/${thoughtId}`);
-        return response.data;
+        const { data } = await this.axiosInstance.get<unknown>(`/thoughts/${brainId}/${thoughtId}`);
+        return ThoughtDto.parse(data);
     }
 
     async createThought(brainId: string, thought: ThoughtCreateModel): Promise<CreateThoughtResponseModel> {
-        const response = await this.axiosInstance.post(`/thoughts/${brainId}`, thought);
-        return response.data;
+        const { data } = await this.axiosInstance.post<unknown>(`/thoughts/${brainId}`, thought);
+        return CreateThoughtResponseModel.parse(data);
     }
 
     async updateThought(brainId: string, thoughtId: string, operations: ThoughtDtoJsonPatchDocument): Promise<void> {
@@ -44,31 +48,38 @@ export class ThoughtsApi {
         await this.axiosInstance.delete(`/thoughts/${brainId}/${thoughtId}`);
     }
 
-    async getThoughtGraph(brainId: string, thoughtId: string, includeSiblings: boolean = false): Promise<any> {
-        const { data } = await this.axiosInstance.get<any>(`/thoughts/${brainId}/${thoughtId}/graph`, {
-            params: { includeSiblings }
-        });
-        return data;
+    async getThoughtGraph(
+        brainId: string,
+        thoughtId: string,
+        includeSiblings: boolean = false
+    ): Promise<ThoughtGraphDto> {
+        const { data } = await this.axiosInstance.get<unknown>(
+            `/thoughts/${brainId}/${thoughtId}/graph`,
+            { params: { includeSiblings } }
+        );
+        return ThoughtGraphDtoSchema.parse(data);
     }
 
-    async getThoughtAttachments(brainId: string, thoughtId: string): Promise<any[]> {
-        const { data } = await this.axiosInstance.get<any[]>(`/thoughts/${brainId}/${thoughtId}/attachments`);
-        return data;
+    async getThoughtAttachments(brainId: string, thoughtId: string): Promise<AttachmentDto[]> {
+        const { data } = await this.axiosInstance.get<unknown>(
+            `/thoughts/${brainId}/${thoughtId}/attachments`
+        );
+        return AttachmentDto.array().parse(data);
     }
 
     async getTypes(brainId: string): Promise<ThoughtDto[]> {
-        const { data } = await this.axiosInstance.get<ThoughtDto[]>(`/thoughts/${brainId}/types`);
-        return data;
+        const { data } = await this.axiosInstance.get<unknown>(`/thoughts/${brainId}/types`);
+        return ThoughtDto.array().parse(data);
     }
 
     async getTags(brainId: string): Promise<ThoughtDto[]> {
-        const { data } = await this.axiosInstance.get<ThoughtDto[]>(`/thoughts/${brainId}/tags`);
-        return data;
+        const { data } = await this.axiosInstance.get<unknown>(`/thoughts/${brainId}/tags`);
+        return ThoughtDto.array().parse(data);
     }
 
     async getPinnedThoughts(brainId: string): Promise<ThoughtDto[]> {
-        const { data } = await this.axiosInstance.get<ThoughtDto[]>(`/thoughts/${brainId}/pins`);
-        return data;
+        const { data } = await this.axiosInstance.get<unknown>(`/thoughts/${brainId}/pins`);
+        return ThoughtDto.array().parse(data);
     }
 
     async pinThought(brainId: string, thoughtId: string): Promise<void> {
@@ -84,10 +95,11 @@ export class ThoughtsApi {
         thoughtId: string,
         maxLogs: number = 100,
         includeRelatedLogs: boolean = true
-    ): Promise<any[]> {
-        const { data } = await this.axiosInstance.get<any[]>(`/thoughts/${brainId}/${thoughtId}/modifications`, {
-            params: { maxLogs, includeRelatedLogs }
-        });
-        return data;
+    ): Promise<ModificationLogDto[]> {
+        const { data } = await this.axiosInstance.get<unknown>(
+            `/thoughts/${brainId}/${thoughtId}/modifications`,
+            { params: { maxLogs, includeRelatedLogs } }
+        );
+        return ModificationLogDto.array().parse(data);
     }
 } 


### PR DESCRIPTION
## Summary
- replace untyped thought APIs with strict DTO parsing
- validate thought graph, attachments, and modifications
- test improper responses for graph, attachment, and modification endpoints

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_b_68b651a5eb9c8325a6e32015c7456f53