### PR TITLE
feat: validate encoded path segments

### DIFF
--- a/src/__tests__/notes-images.test.ts
+++ b/src/__tests__/notes-images.test.ts
@@ -43,3 +43,21 @@ describe('NotesImagesApi.getNoteImageAsDataUrl', () => {
     });
 });
 
+describe('NotesImagesApi path validation', () => {
+    const brainId = '00000000-0000-0000-0000-000000000000';
+
+    it('rejects tokens with encoded path traversal', async () => {
+        const api = new NotesImagesApi({} as AxiosInstance);
+        await expect(
+            api.getNoteImage(brainId, '..%2Fsecret', 'file')
+        ).rejects.toThrow(/Invalid path segment/);
+    });
+
+    it('rejects filenames with encoded backslash traversal', async () => {
+        const api = new NotesImagesApi({} as AxiosInstance);
+        await expect(
+            api.getNoteImage(brainId, 'token', 'image%2e%2e%5c')
+        ).rejects.toThrow(/Invalid path segment/);
+    });
+});
+


### PR DESCRIPTION
## Summary
- harden note image path validation to disallow `%` and URL-encoded traversal
- add tests covering encoded traversal sequences

## Testing
- `yarn test`
- `yarn lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_68b656da98148325bab1d7d38c3bbe7c