### PR TITLE
Clarify BrainDto required fields and add validation tests

### DIFF
--- a/src/__tests__/brain-dto.test.ts
+++ b/src/__tests__/brain-dto.test.ts
@@ -1,0 +1,29 @@
+/** Tests for BrainDto schema validation. */
+import { describe, it, expect } from 'vitest';
+import { BrainDto as BrainDtoSchema } from '../model';
+
+const validBrain = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    brainId: '123e4567-e89b-12d3-a456-426614174000',
+    creationDateTime: '2024-01-01T00:00:00Z',
+    modificationDateTime: '2024-01-01T00:00:00Z',
+    homeThoughtId: '123e4567-e89b-12d3-a456-426614174001',
+    name: 'My Brain'
+};
+
+describe('BrainDto', () => {
+    it('allows optional name', () => {
+        const { name, ...withoutName } = validBrain;
+        expect(() => BrainDtoSchema.parse(withoutName)).not.toThrow();
+    });
+
+    it('throws when id is missing', () => {
+        const { id, ...withoutId } = validBrain;
+        expect(() => BrainDtoSchema.parse(withoutId)).toThrow();
+    });
+
+    it('throws when homeThoughtId is missing', () => {
+        const { homeThoughtId, ...withoutHome } = validBrain;
+        expect(() => BrainDtoSchema.parse(withoutHome)).toThrow();
+    });
+});

--- a/src/model.ts
+++ b/src/model.ts
@@ -97,7 +97,8 @@ const BaseModificationModel = z.object({
 
 // Brain-related schemas
 export const BrainDto = BaseEntitySchema.extend({
-    name: z.string().nullable(),
+    // Name may be omitted or null depending on the API response
+    name: z.string().nullish(),
     homeThoughtId: z.string().uuid(),
 });
 


### PR DESCRIPTION
## Summary
- make BrainDto's name field explicitly optional
- add schema tests to ensure missing required fields cause validation errors

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_68b66db80d348325a63745fe490c38aa